### PR TITLE
Compile dependencies with no debuginfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,8 @@ thiserror = "1"
 tokio = "1.36.0"
 tonic = "0.11.0"
 tonic-build = "0.11.0"
+
+# Do not generate debuginfo for dependencies in `dev` and `test` profiles. This
+# save us some disk space
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Compile dependencies with no debuginfo to save some disk space. Dependencies are compiled with no debuginfo even when `dev` and `test` profiles are active.

**Origin of the idea:** When we are running tests, we are interested in how our code base behaves and not what happens inside dependencies, which should already be tested with their own upstream test suites, so why to bother with generating debug informations for them? Having an oportunity to have more free disk space on GitHub runners is already welcome.

Coverage results are not impacted by this change since control flow inside dependencies are not interesting for the final coverage report.

On the other hand there may be a negative impact on missing some information when printing a call stack, usually during `panic`. In such cases change `debug` to `true`, re-run the failed test, investigate, and revert `debug` back to `false`.