### PR TITLE
fix: update async-nats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0.39"
-async-nats = "0.33.0"
+async-nats = "0.35.1"
 async-trait = "0.1"
 chrono = "0.4.23"
 clap = "4.5.0"


### PR DESCRIPTION
fixes: #66 

This updates nkeys that updates ed25519-dalek

```
Crate:     ed25519-dalek
Version:   1.0.1
Title:     Double Public Key Signing Function Oracle Attack on `ed25519-dalek`
Date:      2022-06-11
ID:        RUSTSEC-2022-0093
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0093
Solution:  Upgrade to >=2
Dependency tree:
ed25519-dalek 1.0.1
└── nkeys 0.2.0
    └── async-nats 0.29.0
        └── guac 0.1.0
```