### PR TITLE
chore: downgrades packageurl to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.11.1"
 exporter = { git = "https://github.com/trustification/trustification.git", tag = "v0.1.0-nightly.9382a428" }
 graphql_client = "0.14.0"
 humantime = "2.1.0"
-packageurl = "0.4.0"
+packageurl = "0.3.0"
 prost = "0.12.3"
 reqwest = "0.11"
 serde = "1.0.114"


### PR DESCRIPTION
if we plan to follow the trustify release approach we need to downgrade this first to have 2 releases later :+1: 